### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    # Group updates to reduce PR count
+    groups:
+      # Group all production dependencies together
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      # Group all development dependencies together
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      # Separate group for major updates (more caution needed)
+      major-dependencies:
+        update-types:
+          - "major"
+    # Auto-label PRs for easier filtering
+    labels:
+      - "dependencies"
+      - "automated"
+    # Increase PR limit if needed
+    open-pull-requests-limit: 10
+    # Commit message prefix
+    commit-message:
+      prefix: "chore"
+      prefix-development: "chore"
+      include: "scope"
+
+  # GitHub Actions updates
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary
- Adds Dependabot configuration to automate dependency updates
- Configures weekly npm dependency checks on Mondays at 9:00 AM
- Groups minor and patch updates by dependency type (production vs development) to reduce PR noise
- Separates major updates into their own group for careful review
- Adds GitHub Actions dependency monitoring
- Configures auto-labeling for easier PR filtering

## Test plan
- [ ] Verify Dependabot configuration is valid by checking GitHub settings
- [ ] Confirm Dependabot starts creating PRs for outdated dependencies
- [ ] Review that PRs are properly grouped and labeled

🤖 Generated with [Claude Code](https://claude.com/claude-code)