### PR TITLE
Update Dependabot configuration and auto-merge workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
+    # Add repo owner as reviewer
+    reviewers:
+      - "97harsh"
     # Group updates to reduce PR count
     groups:
       # Group all production dependencies together
@@ -43,6 +46,9 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
+    # Add repo owner as reviewer
+    reviewers:
+      - "97harsh"
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,57 @@
+name: Dependabot Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Only run on Dependabot PRs
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-approve Dependabot PRs
+        # Auto-approve patch updates to satisfy branch protection rules
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for Dependabot PRs
+        # Auto-merge patch updates automatically
+        # Minor and major updates require manual review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on minor updates
+        # Add a comment on minor updates to alert for manual review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr comment "$PR_URL" --body "ℹ️ This is a **minor version update** and requires manual review before merging."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on major updates
+        # Add a comment on major updates to alert for manual review
+        if: steps.metadata.outputs.update-type == 'version-update:semver-major'
+        run: |
+          gh pr comment "$PR_URL" --body "⚠️ This is a **major version update** and requires manual review before merging."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Added repo owner (97harsh) as reviewer for all Dependabot PRs (npm and GitHub Actions)
- Updated auto-merge workflow to only auto-merge **patch updates** automatically
- Minor and major updates now require manual review with informative comments

## Changes Made

### `.github/dependabot.yml`
- Added `reviewers: ["97harsh"]` to both npm and github-actions configurations
- Ensures you're automatically added as a reviewer on every Dependabot PR

### `.github/workflows/dependabot-auto-merge.yml`
- **Patch updates** (1.2.3 → 1.2.4): Auto-approved and auto-merged
- **Minor updates** (1.2.0 → 1.3.0): Comment added, requires manual review
- **Major updates** (1.0.0 → 2.0.0): Comment added, requires manual review

## Benefits
- Reduces manual work for low-risk patch updates
- Ensures visibility on potentially breaking changes (minor/major)
- You'll be notified as a reviewer for all Dependabot PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)