### PR TITLE
Replace End Game with Forfeit Round in active gameplay

### DIFF
--- a/src/components/game/ForfeitButton.tsx
+++ b/src/components/game/ForfeitButton.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { Flag } from 'lucide-react';
+
+type ForfeitButtonProps = {
+  dispatch: React.Dispatch<any>;
+};
+
+export default function ForfeitButton({ dispatch }: ForfeitButtonProps) {
+  const handleForfeit = () => {
+    dispatch({ type: 'TIME_UP' });
+  };
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive" className="w-full">
+          <Flag className="mr-2 h-4 w-4" /> Forfeit Round
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Forfeit this round?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will end the current round without awarding points and move to the next team's turn.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handleForfeit} className="bg-destructive hover:bg-destructive/90">
+            Forfeit Round
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/game/PlayingScreen.tsx
+++ b/src/components/game/PlayingScreen.tsx
@@ -9,7 +9,7 @@ import { Check, SkipForward, Eye, EyeOff } from 'lucide-react';
 import CategoryIcon from '../icons/CategoryIcon';
 import { useSound } from '@/hooks/useSound';
 import { useHaptic } from '@/hooks/useHaptic';
-import EndGameButton from './EndGameButton';
+import ForfeitButton from './ForfeitButton';
 
 type PlayingScreenProps = {
   gameState: GameState;
@@ -191,7 +191,7 @@ export default function PlayingScreen({ gameState, dispatch }: PlayingScreenProp
       </div>
       }
       <div className="w-full pt-4">
-        <EndGameButton dispatch={dispatch} />
+        <ForfeitButton dispatch={dispatch} />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Created new `ForfeitButton` component that ends only the current round (not the entire game)
- Replaced `EndGameButton` with `ForfeitButton` in `PlayingScreen`
- Players can now forfeit a difficult word/round and move to the next turn without ending the entire game
- "End Game" option remains available on the round summary screen for when players want to completely stop

## Changes Made
### New Files
- [src/components/game/ForfeitButton.tsx](src/components/game/ForfeitButton.tsx) - New forfeit button component

### Modified Files
- [src/components/game/PlayingScreen.tsx](src/components/game/PlayingScreen.tsx#L12) - Replaced EndGameButton with ForfeitButton

## User Experience Improvement
**Before:** During active gameplay, the only way to exit was "End Game" which terminated the entire game immediately.

**After:** 
1. **During Active Play**: "Forfeit Round" button ends current round (no points awarded) → goes to round summary
2. **Round Summary Screen**: "End Game" button ends entire game → goes to game over screen

This provides better game flow control with a step-by-step approach rather than an all-or-nothing option.

## Testing
- ✅ Development server starts successfully
- ✅ TypeScript compilation passes
- ✅ Component renders correctly
- ✅ Forfeit action dispatches `TIME_UP` event
- ✅ Game flow: Playing → Forfeit → Round End → Next Turn

Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)