### PR TITLE
Add One vs All Pictionary Game Mode

### DIFF
--- a/src/app/apps/one-vs-all-pictionary/components/ForfeitButton.tsx
+++ b/src/app/apps/one-vs-all-pictionary/components/ForfeitButton.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import React from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { SkipForward } from 'lucide-react';
+
+type ForfeitButtonProps = {
+  dispatch: React.Dispatch<any>;
+};
+
+export default function ForfeitButton({ dispatch }: ForfeitButtonProps) {
+  const handleForfeit = () => {
+    dispatch({ type: 'FORFEIT_ROUND' });
+  };
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive" className="w-full">
+          <SkipForward className="mr-2 h-4 w-4" /> Forfeit Round
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Forfeit this round?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will skip to the next drawer's turn. No points will be awarded for this round.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={handleForfeit} className="bg-destructive hover:bg-destructive/90">
+            Forfeit Round
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/app/apps/one-vs-all-pictionary/components/GuesserSelectionScreen.tsx
+++ b/src/app/apps/one-vs-all-pictionary/components/GuesserSelectionScreen.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import type { OneVsAllGameState } from "../hooks/useOneVsAllGameEngine";
+import React from 'react';
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { UserCheck, X } from "lucide-react";
+
+type GuesserSelectionScreenProps = {
+    gameState: OneVsAllGameState;
+    dispatch: React.Dispatch<any>;
+};
+
+export default function GuesserSelectionScreen({ gameState, dispatch }: GuesserSelectionScreenProps) {
+    const drawer = gameState.players[gameState.currentTurn.drawerIndex];
+    const guessers = gameState.players.filter(p => p.id !== drawer.id);
+
+    const handleGuesserSelected = (guesserId: number) => {
+        dispatch({ type: 'GUESSER_SELECTED', guesserId });
+    };
+
+    const handleNoOneGuessed = () => {
+        dispatch({ type: 'NO_ONE_GUESSED' });
+    };
+
+    return (
+        <div className="text-center space-y-8 animate-in fade-in duration-500">
+            <div>
+                <h2 className="text-4xl font-bold text-primary">Who guessed it first?</h2>
+                <p className="text-muted-foreground mt-2">Drawer, select the person who shouted the correct answer</p>
+            </div>
+
+            <Card className="bg-card/50">
+                <CardHeader>
+                    <CardTitle className="text-2xl">The word was:</CardTitle>
+                    <CardDescription className="text-3xl font-bold text-foreground">
+                        {gameState.currentRound.word}
+                    </CardDescription>
+                </CardHeader>
+                <CardContent>
+                    <div className="grid grid-cols-2 gap-4">
+                        {guessers.map(player => (
+                            <Button
+                                key={player.id}
+                                onClick={() => handleGuesserSelected(player.id)}
+                                size="lg"
+                                className="h-20 text-xl font-bold bg-accent hover:bg-accent/90"
+                            >
+                                <UserCheck className="mr-2 h-6 w-6" />
+                                {player.name}
+                            </Button>
+                        ))}
+                    </div>
+
+                    <div className="mt-6 pt-6 border-t border-border">
+                        <Button
+                            onClick={handleNoOneGuessed}
+                            variant="outline"
+                            size="lg"
+                            className="w-full h-16 text-lg border-2"
+                        >
+                            <X className="mr-2 h-5 w-5" />
+                            No One Guessed
+                        </Button>
+                    </div>
+                </CardContent>
+            </Card>
+        </div>
+    );
+}

--- a/src/app/apps/one-vs-all-pictionary/components/OneVsAllGameController.tsx
+++ b/src/app/apps/one-vs-all-pictionary/components/OneVsAllGameController.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useOneVsAllGameEngine } from '../hooks/useOneVsAllGameEngine';
+import { useWakeLock } from '@/hooks/useWakeLock';
+import OneVsAllSetupScreen from './OneVsAllSetupScreen';
+import OneVsAllPlayingScreen from './OneVsAllPlayingScreen';
+import OneVsAllGameOverScreen from './OneVsAllGameOverScreen';
+import OneVsAllRoundEndScreen from './OneVsAllRoundEndScreen';
+import OneVsAllTurnStartScreen from './OneVsAllTurnStartScreen';
+import GuesserSelectionScreen from './GuesserSelectionScreen';
+import { Card, CardContent } from '@/components/ui/card';
+
+export default function OneVsAllGameController() {
+  const { gameState, dispatch } = useOneVsAllGameEngine();
+
+  useWakeLock(gameState.status === 'playing');
+
+  const renderScreen = () => {
+    switch (gameState.status) {
+      case 'setup':
+        return <OneVsAllSetupScreen dispatch={dispatch} />;
+      case 'turn_start':
+        return <OneVsAllTurnStartScreen gameState={gameState} dispatch={dispatch} />;
+      case 'playing':
+        return <OneVsAllPlayingScreen gameState={gameState} dispatch={dispatch} />;
+      case 'guesser_selection':
+        return <GuesserSelectionScreen gameState={gameState} dispatch={dispatch} />;
+      case 'round_end':
+        return <OneVsAllRoundEndScreen gameState={gameState} dispatch={dispatch} />;
+      case 'game_over':
+        return <OneVsAllGameOverScreen gameState={gameState} dispatch={dispatch} />;
+      default:
+        return <OneVsAllSetupScreen dispatch={dispatch} />;
+    }
+  };
+
+  return (
+    <Card className="border-2 border-primary/50 shadow-lg shadow-primary/20">
+      <CardContent className="p-4 sm:p-6">
+        {renderScreen()}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/apps/one-vs-all-pictionary/components/OneVsAllGameOverScreen.tsx
+++ b/src/app/apps/one-vs-all-pictionary/components/OneVsAllGameOverScreen.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import React from 'react';
+import type { OneVsAllGameState } from '../hooks/useOneVsAllGameEngine';
+import { Button } from '@/components/ui/button';
+import { RefreshCw, Trophy } from 'lucide-react';
+import Scoreboard from '@/components/game/Scoreboard';
+import Confetti from '@/components/game/Confetti';
+
+type OneVsAllGameOverScreenProps = {
+  gameState: OneVsAllGameState;
+  dispatch: React.Dispatch<any>;
+};
+
+export default function OneVsAllGameOverScreen({ gameState, dispatch }: OneVsAllGameOverScreenProps) {
+  const winner = gameState.players.reduce((prev, current) => (prev.score > current.score) ? prev : current);
+
+  return (
+    <div className="text-center space-y-8">
+        <Confetti />
+        <div className="space-y-2">
+            <Trophy className="mx-auto h-16 w-16 text-yellow-400" />
+            <h2 className="text-4xl font-bold">Game Over!</h2>
+            <p className="text-2xl text-primary">{winner.name} wins the game!</p>
+            <p className="text-lg text-muted-foreground">Final Score: {winner.score} points</p>
+        </div>
+
+        <div className="pt-4">
+            <h3 className="text-xl font-semibold mb-4">Final Scores</h3>
+            <Scoreboard teams={gameState.players} />
+        </div>
+
+      <Button onClick={() => dispatch({ type: 'RESET_GAME' })} size="lg" className="w-full text-lg">
+        <RefreshCw className="mr-2 h-5 w-5" /> Play Again
+      </Button>
+    </div>
+  );
+}

--- a/src/app/apps/one-vs-all-pictionary/components/OneVsAllPlayingScreen.tsx
+++ b/src/app/apps/one-vs-all-pictionary/components/OneVsAllPlayingScreen.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import React, { useState, useEffect, useMemo } from 'react';
+import type { OneVsAllGameState } from '../hooks/useOneVsAllGameEngine';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader } from '@/components/ui/card';
+import { Check, SkipForward, Eye, EyeOff } from 'lucide-react';
+import CategoryIcon from '@/components/icons/CategoryIcon';
+import { useSound } from '@/hooks/useSound';
+import { useHaptic } from '@/hooks/useHaptic';
+import ForfeitButton from './ForfeitButton';
+
+type OneVsAllPlayingScreenProps = {
+  gameState: OneVsAllGameState;
+  dispatch: React.Dispatch<any>;
+};
+
+const WordDisplay = ({ word, revealed, hidden, onReveal, onHide, onShow }: { word: string; revealed: boolean; hidden: boolean; onReveal: () => void; onHide: () => void; onShow: () => void; }) => {
+    if (!revealed) {
+        return (
+            <div className="text-center space-y-6 p-4">
+                <div className="flex flex-col items-center gap-4">
+                    <Eye className="h-16 w-16 text-primary" />
+                    <h2 className="text-3xl font-bold">Are you the drawer?</h2>
+                    <p className="text-muted-foreground max-w-xs text-center">
+                        The word is hidden. Click the button below to reveal it. Make sure the guessers can't see the screen!
+                    </p>
+                </div>
+                <Button onClick={onReveal} size="lg" className="w-full text-lg h-14">
+                    <Eye className="mr-2 h-6 w-6" /> Reveal Word
+                </Button>
+            </div>
+        )
+    }
+
+    if (hidden) {
+        return (
+             <div className="text-center w-full flex items-center justify-center animate-in fade-in duration-300">
+                <Button onClick={onShow} size="lg" className="w-full text-lg h-14">
+                    <Eye className="mr-2 h-6 w-6" /> Show Word
+                </Button>
+            </div>
+        )
+    }
+
+    return (
+        <div className="text-center w-full animate-in fade-in duration-500">
+            <h2 className="text-7xl md:text-8xl lg:text-9xl font-bold tracking-wide text-center break-words leading-tight">
+                {word}
+            </h2>
+            <Button onClick={onHide} variant="ghost" size="sm" className="mt-4 text-muted-foreground">
+                <EyeOff className="mr-2 h-4 w-4" /> Hide Word
+            </Button>
+        </div>
+    );
+};
+
+export default function OneVsAllPlayingScreen({ gameState, dispatch }: OneVsAllPlayingScreenProps) {
+  const { play: playTick, stop: stopTick } = useSound('/sounds/tick.wav', { volume: -10, loop: false });
+  const { play: playEnd } = useSound('/sounds/timesup.wav', { volume: 0 });
+  const { play: playCorrect } = useSound('/sounds/correct.wav', { volume: -5 });
+  const haptic = useHaptic();
+
+  const { settings, currentTurn, currentRound, status } = gameState;
+  const [timeLeft, setTimeLeft] = useState(settings.roundTime);
+  const [wordHidden, setWordHidden] = useState(false);
+
+  const drawer = useMemo(() => gameState.players[currentTurn.drawerIndex], [gameState.players, currentTurn.drawerIndex]);
+  const guessers = useMemo(() => gameState.players.filter(p => p.id !== drawer.id), [gameState.players, drawer.id]);
+
+  useEffect(() => {
+    if (status !== 'playing' || !currentRound.wordRevealed) {
+        return;
+    };
+
+    const timer = setInterval(() => {
+      setTimeLeft(prev => {
+        const newTime = prev - 1;
+        if (newTime <= 0) {
+          clearInterval(timer);
+          stopTick();
+          playEnd();
+          setTimeout(() => dispatch({ type: 'TIME_UP' }), 2000);
+          return 0;
+        }
+        if (newTime <= 10 && newTime > 0) {
+            playTick();
+        }
+        return newTime;
+      });
+    }, 1000);
+
+    return () => {
+        clearInterval(timer);
+        stopTick();
+    };
+  }, [dispatch, status, currentRound.wordRevealed, playEnd, playTick, stopTick]);
+
+  useEffect(() => {
+    if (currentRound.wordRevealed) {
+        setTimeLeft(settings.roundTime);
+    }
+  }, [currentRound.word, currentRound.wordRevealed, settings.roundTime]);
+
+  const handleCorrectGuess = () => {
+    haptic.success();
+    playCorrect();
+    dispatch({ type: 'CORRECT_GUESS' });
+  };
+
+  const handleSkipWord = () => {
+    haptic.tap();
+    dispatch({ type: 'SKIP_WORD' });
+    setWordHidden(false);
+  };
+
+  const handleRevealWord = () => {
+    dispatch({type: 'REVEAL_WORD'});
+    setWordHidden(false);
+  }
+
+  const progressAngle = (timeLeft / settings.roundTime) * 360;
+
+  return (
+    <div className="flex flex-col h-full items-center justify-between space-y-4">
+      <div className="w-full text-center">
+        <p className="text-lg text-primary">Drawer: {drawer.name}</p>
+        <p className="text-sm text-muted-foreground">
+          Guessers: {guessers.map(p => p.name).join(', ')}
+        </p>
+      </div>
+
+      <Card className="w-full flex-grow flex flex-col items-center justify-center p-6 bg-card shadow-xl border-4">
+        <CardHeader className="items-center text-center p-2">
+            <div className="flex items-center gap-3 text-foreground">
+                <CategoryIcon category={currentRound.category} className="h-10 w-10" />
+                <CardDescription className="text-2xl font-semibold">{currentRound.subCategory}</CardDescription>
+            </div>
+        </CardHeader>
+        <CardContent className="flex-grow flex items-center justify-center w-full">
+            <WordDisplay
+              word={currentRound.word}
+              revealed={currentRound.wordRevealed}
+              hidden={wordHidden}
+              onReveal={handleRevealWord}
+              onHide={() => setWordHidden(true)}
+              onShow={() => setWordHidden(false)}
+            />
+        </CardContent>
+      </Card>
+
+    { currentRound.wordRevealed &&
+      <div className="w-full space-y-6 animate-in fade-in duration-500">
+        <div className="flex justify-center items-center">
+            <div
+                className="relative h-48 w-48 md:h-56 md:w-56 rounded-full flex items-center justify-center transition-all duration-1000"
+                style={{
+                    background: `
+                        radial-gradient(closest-side, hsl(var(--card)) 79%, transparent 80% 100%),
+                        conic-gradient(${
+                          timeLeft <= 10
+                            ? 'hsl(var(--timer-danger))'
+                            : timeLeft <= 30
+                              ? 'hsl(var(--timer-warning))'
+                              : 'hsl(var(--primary))'
+                        } ${progressAngle}deg, hsl(var(--muted)) 0)
+                    `,
+                    boxShadow: timeLeft <= 10 ? '0 0 40px hsla(0, 84%, 60%, 0.5)' : 'none'
+                }}
+            >
+                <p className="text-center text-6xl md:text-7xl font-mono font-bold">{timeLeft}</p>
+            </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 w-full">
+          <Button
+            onClick={handleSkipWord}
+            variant="outline"
+            size="lg"
+            className="h-24 md:h-28 text-2xl md:text-3xl font-bold border-4"
+            disabled={currentRound.skipsUsed >= settings.skipLimit}
+          >
+            <SkipForward className="mr-3 h-10 w-10" /> SKIP ({settings.skipLimit - currentRound.skipsUsed})
+          </Button>
+          <Button onClick={handleCorrectGuess} size="lg" className="h-24 md:h-28 text-2xl md:text-3xl font-bold bg-accent hover:bg-accent/90">
+            <Check className="mr-3 h-12 w-12" /> GOT IT!
+          </Button>
+        </div>
+      </div>
+      }
+      <div className="w-full pt-4">
+        <ForfeitButton dispatch={dispatch} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/apps/one-vs-all-pictionary/components/OneVsAllRoundEndScreen.tsx
+++ b/src/app/apps/one-vs-all-pictionary/components/OneVsAllRoundEndScreen.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import type { OneVsAllGameState } from "../hooks/useOneVsAllGameEngine";
+import React from 'react';
+import { Button } from "@/components/ui/button";
+import { ArrowRight } from "lucide-react";
+import Scoreboard from "@/components/game/Scoreboard";
+import Confetti from "@/components/game/Confetti";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import EndGameButton from "@/components/game/EndGameButton";
+
+type OneVsAllRoundEndScreenProps = {
+    gameState: OneVsAllGameState;
+    dispatch: React.Dispatch<any>;
+};
+
+export default function OneVsAllRoundEndScreen({ gameState, dispatch }: OneVsAllRoundEndScreenProps) {
+    const { roundWinner, currentRound, settings } = gameState;
+    const nextDrawerIndex = (gameState.currentTurn.drawerIndex + 1) % gameState.players.length;
+    const nextDrawer = gameState.players[nextDrawerIndex];
+    const currentDrawer = gameState.players[gameState.currentTurn.drawerIndex];
+
+    const handleNextTurn = () => {
+        dispatch({ type: 'ADVANCE_TURN' });
+    };
+
+    return (
+        <div className="text-center space-y-6">
+            {roundWinner && <Confetti />}
+
+            <div className="space-y-2">
+                <h2 className="text-4xl font-bold">
+                    {roundWinner ? `${roundWinner.name} Got It!` : "No One Guessed!"}
+                </h2>
+                {roundWinner ? (
+                    <p className="text-xl text-green-400">
+                        {roundWinner.name} scores +1 point!
+                    </p>
+                ) : (
+                    <div className="space-y-1">
+                        <p className="text-xl text-destructive">
+                            No points awarded this round.
+                        </p>
+                        {settings.penalizeDrawer && !currentRound.anyoneGuessed && (
+                            <p className="text-sm text-muted-foreground">
+                                {currentDrawer.name} loses 0.5 points
+                            </p>
+                        )}
+                    </div>
+                )}
+            </div>
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>The word was:</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <p className="text-4xl font-bold tracking-widest text-accent">{gameState.currentRound.word}</p>
+                </CardContent>
+            </Card>
+
+            <div className="pt-4">
+                 <Scoreboard teams={gameState.players} />
+            </div>
+
+            <Button onClick={handleNextTurn} size="lg" className="w-full text-lg">
+                Next Turn: {nextDrawer.name} draws <ArrowRight className="ml-2 h-5 w-5" />
+            </Button>
+
+            <div className="!mt-8">
+                <EndGameButton dispatch={dispatch} />
+            </div>
+        </div>
+    )
+}

--- a/src/app/apps/one-vs-all-pictionary/components/OneVsAllSetupScreen.tsx
+++ b/src/app/apps/one-vs-all-pictionary/components/OneVsAllSetupScreen.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { useToast } from '@/hooks/use-toast';
+import { X, Plus, Users, Settings, BookOpen, ArrowLeft, HelpCircle, AlertCircle } from 'lucide-react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import CategorySelectionScreen from '@/components/game/CategorySelectionScreen';
+import type { SelectedCategories } from '@/lib/words';
+import Link from 'next/link';
+
+type OneVsAllSetupScreenProps = {
+  dispatch: React.Dispatch<any>;
+};
+
+export default function OneVsAllSetupScreen({ dispatch }: OneVsAllSetupScreenProps) {
+  const [players, setPlayers] = useState<string[]>(['Player 1', 'Player 2', 'Player 3']);
+  const [roundTime, setRoundTime] = useState<number>(60);
+  const [isCustomTime, setIsCustomTime] = useState(false);
+  const [skipLimit, setSkipLimit] = useState<number>(3);
+  const [winningScore, setWinningScore] = useState<number>(20);
+  const [penalizeDrawer, setPenalizeDrawer] = useState<boolean>(true);
+  const [selectedCategories, setSelectedCategories] = useState<SelectedCategories>({
+    'General': { difficulty: 'Beginner', subcategories: ['Objects', 'Actions'] },
+  });
+  const [isCategoryDialogOpen, setCategoryDialogOpen] = useState(false);
+  const { toast } = useToast();
+
+  const handleAddPlayer = () => {
+    if (players.length < 8) {
+      setPlayers([...players, `Player ${players.length + 1}`]);
+    } else {
+      toast({
+        title: "Player Limit Reached",
+        description: "You can have a maximum of 8 players.",
+        variant: "destructive",
+      })
+    }
+  };
+
+  const handleRemovePlayer = (index: number) => {
+    if (players.length > 3) {
+      setPlayers(players.filter((_, i) => i !== index));
+    } else {
+      toast({
+        title: "Minimum Players",
+        description: "You need at least 3 players to play.",
+        variant: "destructive",
+      })
+    }
+  };
+
+  const handlePlayerNameChange = (index: number, name: string) => {
+    const newPlayers = [...players];
+    newPlayers[index] = name;
+    setPlayers(newPlayers);
+  };
+
+  const handleRoundTimeChange = (value: string) => {
+    if (value === 'custom') {
+      setIsCustomTime(true);
+    } else {
+      setIsCustomTime(false);
+      setRoundTime(Number(value));
+    }
+  }
+
+  const handleStartGame = () => {
+    const totalSelected = Object.values(selectedCategories).reduce((acc, val) => acc + (val.subcategories?.length || 0), 0);
+    if (totalSelected === 0) {
+      toast({
+        title: 'No Words to Play With',
+        description: 'Please select at least one word subcategory.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    if (isCustomTime && (roundTime <= 0 || isNaN(roundTime))) {
+        toast({
+            title: 'Invalid Custom Time',
+            description: 'Please enter a valid number of seconds for the round time.',
+            variant: 'destructive'
+        });
+        return;
+    }
+
+    dispatch({
+      type: 'START_GAME',
+      players: players.map(p => p.trim()).filter(Boolean),
+      settings: { roundTime, skipLimit, winningScore, categories: selectedCategories, penalizeDrawer },
+    });
+  };
+
+  const selectedSubcategoryCount = Object.values(selectedCategories).reduce((acc, cat) => acc + (cat.subcategories?.length || 0), 0);
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center">
+        <h1 className="text-4xl font-bold tracking-tighter text-primary">One vs All Pictionary</h1>
+        <p className="text-muted-foreground">Individual player mode - first to shout wins!</p>
+      </div>
+
+      {players.length >= 6 && (
+        <Alert variant="default" className="border-amber-500 bg-amber-50 dark:bg-amber-950">
+          <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+          <AlertTitle>Large Group Detected</AlertTitle>
+          <AlertDescription>
+            Recommended: 3-5 players for best experience. With {players.length} players, it might get chaotic!
+            <br />
+            <Link href="/apps/offline-pictionary" className="text-primary hover:underline font-medium">
+              Want team play instead? Try our team-based mode →
+            </Link>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="space-y-4">
+        <Label className="text-lg font-semibold flex items-center gap-2"><Users className="h-5 w-5" /> Players</Label>
+        <div className="space-y-3">
+          {players.map((player, index) => (
+            <div key={index} className="flex items-center gap-2">
+              <Input
+                type="text"
+                value={player}
+                onChange={e => handlePlayerNameChange(index, e.target.value)}
+                placeholder={`Player ${index + 1} Name`}
+                className="bg-background/50"
+              />
+              <Button variant="ghost" size="icon" onClick={() => handleRemovePlayer(index)} disabled={players.length <= 3}>
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+        <Button variant="outline" onClick={handleAddPlayer} disabled={players.length >= 8}>
+          <Plus className="mr-2 h-4 w-4" /> Add Player
+        </Button>
+      </div>
+
+      <div className="space-y-4">
+        <Label className="text-lg font-semibold flex items-center gap-2"><Settings className="h-5 w-5" /> Game Settings</Label>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="round-time">Round Time</Label>
+            <Select onValueChange={handleRoundTimeChange} defaultValue={String(roundTime)}>
+              <SelectTrigger id="round-time"><SelectValue placeholder="Select time" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="30">30 seconds</SelectItem>
+                <SelectItem value="60">60 seconds</SelectItem>
+                <SelectItem value="90">90 seconds</SelectItem>
+                <SelectItem value="custom">Custom</SelectItem>
+              </SelectContent>
+            </Select>
+            {isCustomTime && (
+                <Input
+                    type="number"
+                    placeholder="Seconds"
+                    value={roundTime}
+                    onChange={(e) => setRoundTime(Number(e.target.value))}
+                    className="mt-2"
+                />
+            )}
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="skip-limit">Skips per Round</Label>
+            <Select onValueChange={value => setSkipLimit(Number(value))} defaultValue={String(skipLimit)}>
+              <SelectTrigger id="skip-limit"><SelectValue placeholder="Select skips" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="1">1 skip</SelectItem>
+                <SelectItem value="2">2 skips</SelectItem>
+                <SelectItem value="3">3 skips</SelectItem>
+                <SelectItem value="5">5 skips</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2 sm:col-span-2">
+            <Label htmlFor="winning-score">Winning Score</Label>
+             <Select onValueChange={value => setWinningScore(Number(value))} defaultValue={String(winningScore)}>
+              <SelectTrigger id="winning-score"><SelectValue placeholder="Select score" /></SelectTrigger>
+              <SelectContent>
+                <SelectItem value="15">15 points</SelectItem>
+                <SelectItem value="20">20 points</SelectItem>
+                <SelectItem value="30">30 points</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2 sm:col-span-2">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="penalize-drawer"
+                checked={penalizeDrawer}
+                onCheckedChange={(checked) => setPenalizeDrawer(checked as boolean)}
+              />
+              <Label htmlFor="penalize-drawer" className="flex items-center gap-2 cursor-pointer">
+                Penalize drawer if no one guesses
+                <TooltipProvider>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <HelpCircle className="h-4 w-4 text-muted-foreground" />
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Drawer loses 0.5 points if no one guesses any word during their turn</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+              </Label>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label className="text-lg font-semibold">Word Categories</Label>
+        <Dialog open={isCategoryDialogOpen} onOpenChange={setCategoryDialogOpen}>
+            <DialogTrigger asChild>
+                <Button variant="outline" className="w-full justify-start text-left font-normal">
+                    <BookOpen className="mr-2 h-4 w-4" />
+                    <span>
+                        {selectedSubcategoryCount > 0 ? `${selectedSubcategoryCount} subcategories selected` : 'Select categories'}
+                    </span>
+                </Button>
+            </DialogTrigger>
+            <DialogContent className="max-w-3xl h-[80vh] flex flex-col">
+                <DialogHeader>
+                    <DialogTitle>Select Word Categories</DialogTitle>
+                </DialogHeader>
+                <div className="flex-grow overflow-y-auto -mx-6 px-6">
+                    <CategorySelectionScreen
+                        initialSelection={selectedCategories}
+                        onSave={(newSelection) => {
+                            setSelectedCategories(newSelection);
+                            setCategoryDialogOpen(false);
+                        }}
+                    />
+                </div>
+            </DialogContent>
+        </Dialog>
+      </div>
+
+      <div className="space-y-4">
+        <Button onClick={handleStartGame} size="lg" className="w-full text-lg bg-accent hover:bg-accent/90">
+            Start Game
+        </Button>
+        <Link href="/" passHref className="block">
+            <Button variant="outline" className="w-full">
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                All Games
+            </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/apps/one-vs-all-pictionary/components/OneVsAllTurnStartScreen.tsx
+++ b/src/app/apps/one-vs-all-pictionary/components/OneVsAllTurnStartScreen.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { OneVsAllGameState } from "../hooks/useOneVsAllGameEngine";
+import React from 'react';
+import { Button } from "@/components/ui/button";
+import { ArrowRight } from "lucide-react";
+import Scoreboard from "@/components/game/Scoreboard";
+import EndGameButton from "@/components/game/EndGameButton";
+
+type OneVsAllTurnStartScreenProps = {
+    gameState: OneVsAllGameState;
+    dispatch: React.Dispatch<any>;
+};
+
+export default function OneVsAllTurnStartScreen({ gameState, dispatch }: OneVsAllTurnStartScreenProps) {
+    const drawer = gameState.players[gameState.currentTurn.drawerIndex];
+    const guessers = gameState.players.filter(p => p.id !== drawer.id);
+
+    return (
+        <div className="text-center space-y-8">
+            <div>
+                <p className="text-lg text-primary">Next Drawer!</p>
+                <h2 className="text-4xl font-bold">{drawer.name}</h2>
+            </div>
+
+            <div className="bg-card/50 p-6 rounded-lg text-center space-y-2">
+                <h3 className="text-2xl font-semibold">Drawer, Get Ready!</h3>
+                <p className="text-muted-foreground">Don't let the guessers see the word!</p>
+                <div className="mt-4 pt-4 border-t border-border">
+                    <p className="text-sm font-semibold text-primary">Guessers:</p>
+                    <p className="text-muted-foreground">{guessers.map(p => p.name).join(', ')}</p>
+                    <p className="text-sm text-muted-foreground mt-2">Shout the answer when you know it!</p>
+                </div>
+            </div>
+
+            <Button onClick={() => dispatch({ type: 'START_ROUND' })} size="lg" className="w-full text-lg">
+                I'm Ready! Start Drawing <ArrowRight className="ml-2 h-5 w-5" />
+            </Button>
+
+            <div className="pt-4">
+                <Scoreboard teams={gameState.players} currentTeamId={drawer.id} />
+            </div>
+
+            <div className="!mt-8">
+                <EndGameButton dispatch={dispatch} />
+            </div>
+        </div>
+    )
+}

--- a/src/app/apps/one-vs-all-pictionary/hooks/useOneVsAllGameEngine.ts
+++ b/src/app/apps/one-vs-all-pictionary/hooks/useOneVsAllGameEngine.ts
@@ -1,0 +1,319 @@
+"use client";
+
+import { useReducer, useEffect, useCallback } from 'react';
+import { getNewWord, type SelectedCategories } from '@/lib/words';
+import type { Team } from '@/hooks/useGameEngine';
+
+export type Player = Team;
+
+export interface OneVsAllGameSettings {
+  roundTime: number;
+  skipLimit: number;
+  winningScore: number;
+  categories: SelectedCategories;
+  penalizeDrawer: boolean;
+}
+
+export interface OneVsAllGameState {
+  status: 'setup' | 'turn_start' | 'playing' | 'guesser_selection' | 'round_end' | 'game_over';
+  players: Player[];
+  settings: OneVsAllGameSettings;
+  currentTurn: {
+    drawerIndex: number;
+  };
+  currentRound: {
+    word: string;
+    category: string;
+    subCategory: string;
+    skipsUsed: number;
+    wordRevealed: boolean;
+    correctGuesserId: number | null;
+    anyoneGuessed: boolean;
+  };
+  roundWinner: Player | null;
+  usedWords: string[];
+}
+
+type GameAction =
+  | { type: 'START_GAME'; players: string[]; settings: OneVsAllGameSettings }
+  | { type: 'START_ROUND' }
+  | { type: 'REVEAL_WORD' }
+  | { type: 'CORRECT_GUESS' }
+  | { type: 'GUESSER_SELECTED'; guesserId: number }
+  | { type: 'NO_ONE_GUESSED' }
+  | { type: 'SKIP_WORD' }
+  | { type: 'TIME_UP' }
+  | { type: 'FORFEIT_ROUND' }
+  | { type: 'RESET_GAME' }
+  | { type: 'ADVANCE_TURN' }
+  | { type: 'FORCE_GAME_OVER' }
+  | { type: 'LOAD_STATE'; state: OneVsAllGameState };
+
+const initialState: OneVsAllGameState = {
+  status: 'setup',
+  players: [],
+  settings: {
+    roundTime: 60,
+    skipLimit: 3,
+    winningScore: 20,
+    categories: {},
+    penalizeDrawer: true,
+  },
+  currentTurn: {
+    drawerIndex: 0,
+  },
+  currentRound: {
+    word: '',
+    category: '',
+    subCategory: '',
+    skipsUsed: 0,
+    wordRevealed: false,
+    correctGuesserId: null,
+    anyoneGuessed: false,
+  },
+  roundWinner: null,
+  usedWords: [],
+};
+
+function gameReducer(state: OneVsAllGameState, action: GameAction): OneVsAllGameState {
+  switch (action.type) {
+    case 'LOAD_STATE':
+        return action.state;
+
+    case 'START_GAME': {
+      const { players, settings } = action;
+      const newWordData = getNewWord([], settings.categories);
+
+      if (!newWordData) {
+        return state;
+      }
+
+      return {
+        ...initialState,
+        status: 'turn_start',
+        players: players.map((name, i) => ({ id: i, name, score: 0 })),
+        settings,
+        currentRound: {
+            ...initialState.currentRound,
+            word: newWordData.word,
+            category: newWordData.category,
+            subCategory: newWordData.subCategory,
+        },
+        usedWords: [newWordData.word],
+      };
+    }
+
+    case 'START_ROUND':
+        return {
+            ...state,
+            status: 'playing',
+            currentRound: {
+                ...state.currentRound,
+                wordRevealed: false,
+            },
+            roundWinner: null,
+        }
+
+    case 'REVEAL_WORD':
+        return {
+            ...state,
+            currentRound: {
+                ...state.currentRound,
+                wordRevealed: true,
+            }
+        }
+
+    case 'CORRECT_GUESS': {
+      return {
+        ...state,
+        status: 'guesser_selection',
+      };
+    }
+
+    case 'GUESSER_SELECTED': {
+      const newPlayers = [...state.players];
+      const guesser = newPlayers.find(p => p.id === action.guesserId)!;
+      guesser.score += 1;
+
+      const winner = newPlayers.find(p => p.score >= state.settings.winningScore);
+
+      return {
+        ...state,
+        players: newPlayers,
+        status: winner ? 'game_over' : 'round_end',
+        roundWinner: guesser,
+        currentRound: {
+          ...state.currentRound,
+          correctGuesserId: action.guesserId,
+          anyoneGuessed: true,
+        },
+      };
+    }
+
+    case 'NO_ONE_GUESSED': {
+      const newPlayers = [...state.players];
+
+      if (state.settings.penalizeDrawer) {
+        const drawer = newPlayers[state.currentTurn.drawerIndex];
+        drawer.score = Math.max(0, drawer.score - 0.5);
+      }
+
+      return {
+        ...state,
+        players: newPlayers,
+        status: 'round_end',
+        roundWinner: null,
+        currentRound: {
+          ...state.currentRound,
+          anyoneGuessed: false,
+        },
+      };
+    }
+
+    case 'SKIP_WORD': {
+      if (state.currentRound.skipsUsed >= state.settings.skipLimit) return state;
+
+      const newWordData = getNewWord(state.usedWords, state.settings.categories);
+
+      if (!newWordData) {
+        return { ...state, status: 'game_over' };
+      }
+
+      return {
+        ...state,
+        currentRound: {
+          ...state.currentRound,
+          word: newWordData.word,
+          category: newWordData.category,
+          subCategory: newWordData.subCategory,
+          skipsUsed: state.currentRound.skipsUsed + 1,
+          wordRevealed: true,
+        },
+        usedWords: [...state.usedWords, newWordData.word],
+      };
+    }
+
+    case 'TIME_UP': {
+      const newPlayers = [...state.players];
+
+      if (!state.currentRound.anyoneGuessed && state.settings.penalizeDrawer) {
+        const drawer = newPlayers[state.currentTurn.drawerIndex];
+        drawer.score = Math.max(0, drawer.score - 0.5);
+      }
+
+      return {
+        ...state,
+        players: newPlayers,
+        status: 'round_end',
+        roundWinner: null,
+      };
+    }
+
+    case 'FORFEIT_ROUND': {
+      const nextDrawerIndex = (state.currentTurn.drawerIndex + 1) % state.players.length;
+      const newWordData = getNewWord(state.usedWords, state.settings.categories);
+
+      if (!newWordData) {
+        return { ...state, status: 'game_over' };
+      }
+
+      return {
+        ...state,
+        status: 'turn_start',
+        roundWinner: null,
+        currentTurn: {
+            drawerIndex: nextDrawerIndex,
+        },
+        currentRound: {
+            word: newWordData.word,
+            category: newWordData.category,
+            subCategory: newWordData.subCategory,
+            skipsUsed: 0,
+            wordRevealed: false,
+            correctGuesserId: null,
+            anyoneGuessed: false,
+        },
+        usedWords: [...state.usedWords, newWordData.word],
+      };
+    }
+
+    case 'ADVANCE_TURN': {
+      const nextDrawerIndex = (state.currentTurn.drawerIndex + 1) % state.players.length;
+      const newWordData = getNewWord(state.usedWords, state.settings.categories);
+
+      if (!newWordData) {
+        return { ...state, status: 'game_over' };
+      }
+
+      return {
+        ...state,
+        status: 'turn_start',
+        roundWinner: null,
+        currentTurn: {
+            drawerIndex: nextDrawerIndex,
+        },
+        currentRound: {
+            word: newWordData.word,
+            category: newWordData.category,
+            subCategory: newWordData.subCategory,
+            skipsUsed: 0,
+            wordRevealed: false,
+            correctGuesserId: null,
+            anyoneGuessed: false,
+        },
+        usedWords: [...state.usedWords, newWordData.word],
+      };
+    }
+
+    case 'FORCE_GAME_OVER': {
+        return {
+            ...state,
+            status: 'game_over',
+        }
+    }
+
+    case 'RESET_GAME':
+      return initialState;
+
+    default:
+      return state;
+  }
+}
+
+const STORAGE_KEY = 'one_vs_all_pictionary_state';
+
+export function useOneVsAllGameEngine() {
+  const [state, dispatch] = useReducer(gameReducer, initialState);
+
+  useEffect(() => {
+    try {
+      const savedState = localStorage.getItem(STORAGE_KEY);
+      if (savedState) {
+        const parsed = JSON.parse(savedState);
+        if (parsed.status && parsed.players) {
+            dispatch({ type: 'LOAD_STATE', state: parsed });
+        }
+      }
+    } catch (error) {
+      console.error("Failed to load state from localStorage", error);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (state.status !== 'setup') {
+        try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+        } catch (error) {
+            console.error("Failed to save state to localStorage", error);
+        }
+    } else {
+        localStorage.removeItem(STORAGE_KEY);
+    }
+  }, [state]);
+
+  const gameDispatch = useCallback((action: GameAction) => {
+    dispatch(action);
+  }, []);
+
+  return { gameState: state, dispatch: gameDispatch };
+}

--- a/src/app/apps/one-vs-all-pictionary/page.tsx
+++ b/src/app/apps/one-vs-all-pictionary/page.tsx
@@ -1,0 +1,12 @@
+'use client';
+import OneVsAllGameController from './components/OneVsAllGameController';
+
+export default function OneVsAllPictionaryPage() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center p-4 sm:p-6 md:p-8">
+      <div className="w-full max-w-2xl mx-auto relative">
+        <OneVsAllGameController />
+      </div>
+    </main>
+  );
+}

--- a/src/lib/apps.ts
+++ b/src/lib/apps.ts
@@ -1,5 +1,5 @@
 
-import { Paintbrush, type LucideIcon } from 'lucide-react';
+import { Paintbrush, Users, type LucideIcon } from 'lucide-react';
 
 export interface App {
   id: string;
@@ -12,10 +12,17 @@ export interface App {
 export const APPS: App[] = [
   {
     id: 'offline-pictionary',
-    title: 'Offline Pictionary',
-    description: 'A digital assistant for your Pictionary and other drawing games. Generates words, keeps score, and manages turns.',
+    title: 'Team Pictionary',
+    description: 'A digital assistant for team-based Pictionary. Generates words, keeps score, and manages team turns.',
     href: '/apps/offline-pictionary',
     icon: Paintbrush,
+  },
+  {
+    id: 'one-vs-all-pictionary',
+    title: 'One vs All Pictionary',
+    description: 'Solo glory edition! One player draws while everyone else competes to guess first. First to shout the answer wins points.',
+    href: '/apps/one-vs-all-pictionary',
+    icon: Users,
   },
   // Add new apps here in the future
 ];


### PR DESCRIPTION
## Summary
Implement a new one-vs-all Pictionary game mode where one player draws while everyone else competes to guess first. Only the first person to shout the correct answer gets points.

## Key Features

### 🎮 Game Mechanics
- **One drawer, multiple guessers**: Players take turns being the drawer
- **First to shout wins**: Only the first guesser gets +1 point
- **Optional drawer penalty**: -0.5 points if no one guesses (configurable in setup)
- **3-8 players supported**: Recommended 3-5 for best experience

### 🎯 Scoring System
- First guesser: +1 point per correct answer
- Drawer penalty: -0.5 points when no one guesses (optional, enabled by default)
- Scores support decimals (0.5, 1.5, 2.0, etc.)
- Score never goes below 0

### 🔄 Game Flow
1. **Setup Screen**: Enter player names (3-8), configure settings, toggle penalty
2. **Turn Start**: Shows current drawer + list of guessers
3. **Playing**: Word reveal, timer, GOT IT/SKIP buttons
4. **Guesser Selection**: NEW - Drawer selects who guessed first from a grid
5. **Round End**: Shows winner and updated scores
6. **Game Over**: Winner announcement with final scores

### 🎨 User Experience
- Warning banner when 6+ players: "Recommended: 3-5 players for best experience"
- Link to team-based mode for larger groups
- "Forfeit Round" button during gameplay (skips to next drawer)
- "No One Guessed" option in guesser selection screen
- Penalty toggle with helpful tooltip explaining the -0.5 rule
- Reuses familiar UI patterns from team-based mode

### 🏗️ Technical Implementation
- **New game engine**: `useOneVsAllGameEngine` with one-vs-all specific logic
- **Separate component set**: All components in `/apps/one-vs-all-pictionary`
- **Shared resources**: Same word database and UI components as team mode
- **localStorage persistence**: Unique key to avoid conflicts
- **Type-safe**: Reuses `Team` interface as `Player` type alias

## Navigation
- App Hub now shows both game modes
- One-vs-all setup links to team mode when 6+ players
- Both modes share the same category selection system

## Files Created
- `src/app/apps/one-vs-all-pictionary/page.tsx` - Entry point
- `src/app/apps/one-vs-all-pictionary/hooks/useOneVsAllGameEngine.ts` - Game engine
- `src/app/apps/one-vs-all-pictionary/components/OneVsAllGameController.tsx` - Screen router
- `src/app/apps/one-vs-all-pictionary/components/OneVsAllSetupScreen.tsx` - Setup flow
- `src/app/apps/one-vs-all-pictionary/components/OneVsAllTurnStartScreen.tsx` - Turn transition
- `src/app/apps/one-vs-all-pictionary/components/OneVsAllPlayingScreen.tsx` - Gameplay
- `src/app/apps/one-vs-all-pictionary/components/GuesserSelectionScreen.tsx` - NEW unique screen
- `src/app/apps/one-vs-all-pictionary/components/OneVsAllRoundEndScreen.tsx` - Round results
- `src/app/apps/one-vs-all-pictionary/components/OneVsAllGameOverScreen.tsx` - Game end
- `src/app/apps/one-vs-all-pictionary/components/ForfeitButton.tsx` - Forfeit functionality

## Files Modified
- `src/lib/apps.ts` - Added One vs All entry to app registry

## Testing Checklist
- [x] Setup flow works with 3-8 players
- [x] Warning shows at 6+ players with team mode link
- [x] Penalty toggle works correctly
- [x] Drawer selection shows all guessers except current drawer
- [x] "No one guessed" applies penalty correctly (when enabled)
- [x] Forfeit round skips to next drawer
- [x] Scores update correctly (+1 for guesser, -0.5 for drawer)
- [x] Game ends when winning score reached
- [x] localStorage persistence works

## Screenshots
(Add screenshots if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)